### PR TITLE
fix(agent): Open AI provider tools enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,83 @@
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+#### OpenAI-compatible provider: tool calls silently dropped during streaming
+
+**Problem**
+
+When using the OpenAI provider with a local llama-server backend (or any
+OpenAI-compatible endpoint), tool calls are never executed. The model
+reports its available tools correctly, but when asked to use one it emits
+raw XML-like text instead of producing structured tool calls:
+
+```
+LocalGPT: <tool_call>
+<bash>
+pwd
+</tool_call>
+</tool_call>
+```
+
+The tools are never executed. The session transcript confirms the
+response arrives as plain text content, not as a `tool_calls` array:
+
+```json
+{
+  "content": [
+    {
+      "text": "<tool_call>\n<bash>\npwd\n</tool_call>\n</tool_call>",
+      "type": "text"
+    }
+  ],
+  "role": "assistant"
+}
+```
+
+However, hitting llama-server directly via curl with the same tool
+schemas returns a correctly structured response with
+`"finish_reason": "tool_calls"` and a valid `tool_calls` array.
+
+**Diagnosis**
+
+The `OpenAIProvider` implements `chat()` and `summarize()` but does not
+implement `chat_stream()`. The interactive chat CLI uses the streaming
+path (`agent.chat_stream_with_images()`), which falls through to the
+default `chat_stream` implementation on the `LLMProvider` trait.
+
+Two bugs in the default fallback (`src/agent/providers.rs`, lines
+152-173):
+
+1. **Tools are dropped.** The fallback calls `self.chat(messages, None)`
+   — passing `None` for the tools parameter instead of forwarding the
+   tools it received. The model never sees tool schemas in the API
+   request, so it cannot produce structured `tool_calls` responses. It
+   falls back to emitting its training-time tool format as raw text.
+
+2. **ToolCalls response is treated as an error.** If `chat()` were to
+   return `LLMResponseContent::ToolCalls`, the fallback returns
+   `Err("Tool calls not supported in streaming")` instead of converting
+   the tool calls into a `StreamChunk` with the `tool_calls` field
+   populated.
+
+The combination means: the model never receives tool schemas (bug 1),
+and even if it did, the response would be discarded (bug 2).
+
+**Impact**
+
+Any provider that relies on the default `chat_stream` fallback — which
+currently includes `OpenAIProvider` — cannot execute tools when used via
+the interactive chat CLI. This affects all OpenAI-compatible local
+backends (llama-server, vLLM, LM Studio, etc.) and the OpenAI API
+itself.
+
+The Anthropic and Ollama providers are unaffected because they implement
+their own `chat_stream`. (Ollama separately drops tools intentionally.)
+
+**Fix**
+
+1. Forward the `tools` parameter in the default `chat_stream` fallback.
+2. Convert `ToolCalls` responses into a `StreamChunk` with `tool_calls`
+   populated instead of returning an error.

--- a/src/agent/test/unit/openaiprovider_tool_test.rs
+++ b/src/agent/test/unit/openaiprovider_tool_test.rs
@@ -1,0 +1,147 @@
+//! Tests for the default `chat_stream` fallback on `LLMProvider`.
+//!
+//! The default implementation delegates to `chat()` and wraps the result
+//! in a single `StreamChunk`. These tests verify that:
+//!   1. Tool schemas are forwarded (not dropped)
+//!   2. Text responses produce a valid stream chunk
+//!   3. ToolCalls responses produce a stream chunk with tool_calls populated
+
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::StreamExt;
+
+use super::*;
+
+/// Mock provider that returns a configured response from chat(),
+/// used to test the default chat_stream fallback on LLMProvider.
+struct MockProvider {
+    response: std::sync::Mutex<Option<LLMResponse>>,
+    /// Captures whether tools were forwarded to chat()
+    received_tools: std::sync::Mutex<bool>,
+}
+
+impl MockProvider {
+    fn returning_text(text: &str) -> Self {
+        Self {
+            response: std::sync::Mutex::new(Some(LLMResponse::text(text.to_string()))),
+            received_tools: std::sync::Mutex::new(false),
+        }
+    }
+
+    fn returning_tool_calls(calls: Vec<ToolCall>) -> Self {
+        Self {
+            response: std::sync::Mutex::new(Some(LLMResponse::tool_calls(calls))),
+            received_tools: std::sync::Mutex::new(false),
+        }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for MockProvider {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        tools: Option<&[ToolSchema]>,
+    ) -> Result<LLMResponse> {
+        if let Some(t) = tools {
+            if !t.is_empty() {
+                *self.received_tools.lock().unwrap() = true;
+            }
+        }
+        self.response
+            .lock()
+            .unwrap()
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("MockProvider exhausted"))
+    }
+
+    async fn summarize(&self, _text: &str) -> Result<String> {
+        Ok(String::new())
+    }
+}
+
+#[tokio::test]
+async fn test_default_chat_stream_forwards_tools() {
+    let provider = MockProvider::returning_text("hello");
+    let messages = vec![Message {
+        role: Role::User,
+        content: "test".to_string(),
+        tool_calls: None,
+        tool_call_id: None,
+        images: Vec::new(),
+    }];
+    let tools = vec![ToolSchema {
+        name: "bash".to_string(),
+        description: "Execute a command".to_string(),
+        parameters: serde_json::json!({"type": "object"}),
+    }];
+
+    let _stream = provider
+        .chat_stream(&messages, Some(&tools))
+        .await
+        .expect("chat_stream should succeed");
+
+    assert!(
+        *provider.received_tools.lock().unwrap(),
+        "Default chat_stream must forward tools to chat()"
+    );
+}
+
+#[tokio::test]
+async fn test_default_chat_stream_returns_text_as_stream_chunk() {
+    let provider = MockProvider::returning_text("hello world");
+    let messages = vec![Message {
+        role: Role::User,
+        content: "test".to_string(),
+        tool_calls: None,
+        tool_call_id: None,
+        images: Vec::new(),
+    }];
+
+    let mut stream = provider
+        .chat_stream(&messages, None)
+        .await
+        .expect("chat_stream should succeed");
+
+    let chunk = stream.next().await.expect("stream should yield a chunk");
+    let chunk = chunk.expect("chunk should be Ok");
+
+    assert_eq!(chunk.delta, "hello world");
+    assert!(chunk.done);
+    assert!(chunk.tool_calls.is_none());
+}
+
+#[tokio::test]
+async fn test_default_chat_stream_returns_tool_calls_as_stream_chunk() {
+    let calls = vec![ToolCall {
+        id: "call_1".to_string(),
+        name: "bash".to_string(),
+        arguments: "{\"command\":\"pwd\"}".to_string(),
+    }];
+    let provider = MockProvider::returning_tool_calls(calls);
+    let messages = vec![Message {
+        role: Role::User,
+        content: "test".to_string(),
+        tool_calls: None,
+        tool_call_id: None,
+        images: Vec::new(),
+    }];
+
+    let mut stream = provider
+        .chat_stream(&messages, None)
+        .await
+        .expect("chat_stream should succeed");
+
+    let chunk = stream.next().await.expect("stream should yield a chunk");
+    let chunk = chunk.expect("chunk should be Ok");
+
+    assert!(chunk.done);
+    assert!(
+        chunk.delta.is_empty(),
+        "tool call chunk should have empty delta"
+    );
+    let tool_calls = chunk.tool_calls.expect("chunk should contain tool_calls");
+    assert_eq!(tool_calls.len(), 1);
+    assert_eq!(tool_calls[0].name, "bash");
+    assert_eq!(tool_calls[0].arguments, "{\"command\":\"pwd\"}");
+}


### PR DESCRIPTION
The default chat_stream fallback on LLMProvider had two bugs that prevented tool calling for any provider without its own chat_stream implementation (currently OpenAIProvider):

1. Tools were dropped — self.chat(messages, None) passed None instead of forwarding the tools parameter.
2. ToolCalls responses were treated as errors instead of being converted to StreamChunk with tool_calls populated.

This affected all OpenAI-compatible local backends (llama-server, vLLM, LM Studio) and the OpenAI API when used via the streaming chat CLI.

Tested end-to-end with MiniMax M2.1 (Q2_K) via llama-server. All seven agent tools (bash, read_file, write_file, edit_file, memory_search, memory_get, web_fetch) confirmed working.

See CHANGELOG.md for full diagnosis.
Run unit tests: cargo test --lib agent::providers

Claude contribution openly acknowledged in tandem with project SOUL.