### PR TITLE
feat: Enable Ollama tool calling support

### DIFF
--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -1020,6 +1020,37 @@ impl LLMProvider for OllamaProvider {
             .send()
             .await?;
 
+        // If Ollama returns 400 (model doesn't support tools), retry without tools
+        if response.status() == reqwest::StatusCode::BAD_REQUEST && body.get("tools").is_some() {
+            debug!("Ollama returned 400 with tools, retrying without tools");
+            let mut body_no_tools = body.clone();
+            body_no_tools.as_object_mut().map(|o| o.remove("tools"));
+            let retry_response = self
+                .client
+                .post(format!("{}/api/chat", self.endpoint))
+                .header("Content-Type", "application/json")
+                .json(&body_no_tools)
+                .send()
+                .await?;
+            let response_body: Value = retry_response.json().await?;
+            let content = response_body["message"]["content"]
+                .as_str()
+                .unwrap_or("")
+                .to_string();
+            let usage = if response_body.get("prompt_eval_count").is_some() {
+                Some(Usage {
+                    input_tokens: response_body["prompt_eval_count"].as_u64().unwrap_or(0),
+                    output_tokens: response_body["eval_count"].as_u64().unwrap_or(0),
+                })
+            } else {
+                None
+            };
+            return Ok(LLMResponse {
+                content: LLMResponseContent::Text(content),
+                usage,
+            });
+        }
+
         let response_body: Value = response.json().await?;
         debug!(
             "Ollama response: {}",

--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -948,29 +948,67 @@ impl LLMProvider for OllamaProvider {
     async fn chat(
         &self,
         messages: &[Message],
-        _tools: Option<&[ToolSchema]>,
+        tools: Option<&[ToolSchema]>,
     ) -> Result<LLMResponse> {
-        // Note: Ollama tool support is limited, so we format as plain chat
         let formatted_messages: Vec<Value> = messages
             .iter()
             .map(|m| {
-                json!({
+                let mut msg = json!({
                     "role": match m.role {
                         Role::System => "system",
                         Role::User => "user",
                         Role::Assistant => "assistant",
-                        Role::Tool => "user", // Treat tool results as user messages
+                        Role::Tool => "tool",
                     },
                     "content": m.content
-                })
+                });
+                // Include tool_call_id for tool role messages
+                if m.role == Role::Tool {
+                    if let Some(ref id) = m.tool_call_id {
+                        msg["tool_call_id"] = json!(id);
+                    }
+                }
+                // Include tool_calls for assistant messages that had them
+                if m.role == Role::Assistant {
+                    if let Some(ref calls) = m.tool_calls {
+                        let tc: Vec<Value> = calls.iter().map(|c| json!({
+                            "function": {
+                                "name": c.name,
+                                "arguments": serde_json::from_str::<Value>(&c.arguments).unwrap_or(json!({}))
+                            }
+                        })).collect();
+                        msg["tool_calls"] = json!(tc);
+                    }
+                }
+                msg
             })
             .collect();
 
-        let body = json!({
+        let mut body = json!({
             "model": self.model,
             "messages": formatted_messages,
             "stream": false
         });
+
+        // Send tool schemas if provided
+        if let Some(tool_schemas) = tools {
+            if !tool_schemas.is_empty() {
+                let tools_json: Vec<Value> = tool_schemas
+                    .iter()
+                    .map(|t| {
+                        json!({
+                            "type": "function",
+                            "function": {
+                                "name": t.name,
+                                "description": t.description,
+                                "parameters": t.parameters
+                            }
+                        })
+                    })
+                    .collect();
+                body["tools"] = json!(tools_json);
+            }
+        }
 
         debug!("Ollama request: {}", serde_json::to_string_pretty(&body)?);
 
@@ -988,11 +1026,6 @@ impl LLMProvider for OllamaProvider {
             serde_json::to_string_pretty(&response_body)?
         );
 
-        let content = response_body["message"]["content"]
-            .as_str()
-            .unwrap_or("")
-            .to_string();
-
         // Ollama returns token counts in prompt_eval_count and eval_count
         let usage = if response_body.get("prompt_eval_count").is_some() {
             Some(Usage {
@@ -1002,6 +1035,41 @@ impl LLMProvider for OllamaProvider {
         } else {
             None
         };
+
+        // Check for tool calls in response
+        if let Some(tool_calls) = response_body["message"]["tool_calls"].as_array() {
+            if !tool_calls.is_empty() {
+                let calls: Vec<ToolCall> = tool_calls
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, tc)| {
+                        let name = tc["function"]["name"].as_str()?.to_string();
+                        let arguments = if tc["function"]["arguments"].is_object() {
+                            serde_json::to_string(&tc["function"]["arguments"]).ok()?
+                        } else {
+                            tc["function"]["arguments"].as_str()?.to_string()
+                        };
+                        Some(ToolCall {
+                            id: format!("call_{}", i),
+                            name,
+                            arguments,
+                        })
+                    })
+                    .collect();
+
+                if !calls.is_empty() {
+                    return Ok(LLMResponse {
+                        content: LLMResponseContent::ToolCalls(calls),
+                        usage,
+                    });
+                }
+            }
+        }
+
+        let content = response_body["message"]["content"]
+            .as_str()
+            .unwrap_or("")
+            .to_string();
 
         Ok(LLMResponse {
             content: LLMResponseContent::Text(content),
@@ -1030,8 +1098,33 @@ impl LLMProvider for OllamaProvider {
     async fn chat_stream(
         &self,
         messages: &[Message],
-        _tools: Option<&[ToolSchema]>,
+        tools: Option<&[ToolSchema]>,
     ) -> Result<StreamResult> {
+        // For tool-enabled requests, use non-streaming to properly handle tool calls
+        if tools.is_some() && tools.map(|t| !t.is_empty()).unwrap_or(false) {
+            let resp = self.chat(messages, tools).await?;
+            return match resp.content {
+                LLMResponseContent::Text(text) => {
+                    Ok(Box::pin(futures::stream::once(async move {
+                        Ok(StreamChunk {
+                            delta: text,
+                            done: true,
+                            tool_calls: None,
+                        })
+                    })))
+                }
+                LLMResponseContent::ToolCalls(calls) => {
+                    Ok(Box::pin(futures::stream::once(async move {
+                        Ok(StreamChunk {
+                            delta: String::new(),
+                            done: true,
+                            tool_calls: Some(calls),
+                        })
+                    })))
+                }
+            };
+        }
+
         let formatted_messages: Vec<Value> = messages
             .iter()
             .map(|m| {
@@ -1040,7 +1133,7 @@ impl LLMProvider for OllamaProvider {
                         Role::System => "system",
                         Role::User => "user",
                         Role::Assistant => "assistant",
-                        Role::Tool => "user",
+                        Role::Tool => "tool",
                     },
                     "content": m.content
                 })


### PR DESCRIPTION
## Summary

This PR enables native tool calling for the Ollama provider, which was previously disabled (`_tools` parameter ignored).

Ollama has supported OpenAI-compatible tool calling since [v0.3.0](https://github.com/ollama/ollama/releases/tag/v0.3.0) (July 2024), but LocalGPT's Ollama provider was treating all requests as plain chat — tools were never sent to the API and tool call responses were never parsed.

## Changes

### `src/agent/providers.rs` — `OllamaProvider`

**`chat()` method:**
- Accept and forward `tools` parameter (was `_tools`, ignored)
- Format tool schemas as OpenAI-compatible `tools` array in the request body
- Parse `tool_calls` from Ollama responses and return as `LLMResponseContent::ToolCalls`
- Handle `Tool` role messages properly (was mapped to `user`, now correctly set to `tool` with `tool_call_id`)
- Include assistant `tool_calls` in message history for multi-turn tool conversations
- **Graceful fallback:** If Ollama returns HTTP 400 (model doesn't support tools), automatically retry the request without tools. This ensures models like `smollm2:135m` continue to work as plain chat while tool-capable models like `qwen3:0.6b` get full tool support.

**`chat_stream()` method:**
- Accept `tools` parameter (was `_tools`, ignored)
- When tools are provided, fall back to non-streaming `chat()` to reliably capture tool call responses (Ollama's streaming doesn't consistently return structured tool calls)
- Plain text requests continue to stream normally

## Testing

Tested with `qwen3:0.6b` via Ollama. The model was asked:

```
localgpt ask "Write a Python script that prints 'Hello White Lobster' and save it to /workspace/hello.py"
```

The model successfully produced a `write_file` tool call, LocalGPT executed it, and the file was created on disk.

Also verified that `smollm2:135m` (which doesn't support tools) continues to work normally via the automatic fallback — no errors, plain chat as before.

## Notes

- Not all Ollama models support tool calling — smaller models (<1B params) may not produce valid tool call JSON. The graceful fallback handles this transparently.
- The streaming fallback for tool-enabled requests is intentional. Ollama's streaming mode doesn't reliably return `tool_calls` in chunk responses. Once Ollama improves streaming tool support, this can be revisited.
- Backward compatible — models that don't support tools will simply fall back to plain chat, behavior unchanged.