### PR TITLE
feat: add Telegram bot interface with pairing auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+#### Telegram bot interface
+
+Access LocalGPT from Telegram with full chat, tool use, and memory support.
+Configure with `[telegram]` in `config.toml`, pair via a one-time 6-digit code,
+and use slash commands (`/help`, `/new`, `/model`, `/memory`, etc.) just like
+the CLI. Runs as a background task inside the daemon.
+
 ### Fixed
 
 #### OpenAI-compatible provider: tool calls silently dropped during streaming

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,14 +48,17 @@ LocalGPT is a local-only AI assistant with persistent markdown-based memory and 
 - **heartbeat/** - Autonomous task runner
   - `runner.rs` - Runs on configurable interval within active hours. Reads `HEARTBEAT.md` and executes pending tasks
 
-- **server/** - HTTP/WebSocket API
+- **server/** - HTTP/WebSocket API and Telegram bot
   - `http.rs` - Axum-based REST API. Note: creates new Agent per request (no session persistence via HTTP)
+  - `telegram.rs` - Telegram bot interface with one-time pairing auth, per-chat sessions, streaming responses with debounced message edits (2s), and full tool support
   - Endpoints: `/health`, `/api/status`, `/api/chat`, `/api/memory/search`, `/api/memory/stats`
 
 - **config/** - TOML configuration at `~/.localgpt/config.toml`
   - Supports `${ENV_VAR}` expansion in API keys
   - `workspace_path()` returns expanded memory workspace path
   - `migrate.rs` - Auto-migrates from OpenClaw's `~/.openclaw/config.json5` if LocalGPT config doesn't exist
+
+- **commands.rs** - Shared slash command definitions used by both CLI chat and Telegram bot
 
 - **cli/** - Clap-based subcommands: `chat`, `ask`, `daemon`, `memory`, `config`
 
@@ -79,6 +82,49 @@ Key settings:
 - `heartbeat.interval` - Duration string (e.g., "30m", "1h")
 - `heartbeat.active_hours` - Optional `{start, end}` in "HH:MM" format
 - `server.port` - HTTP server port (default: 31327)
+- `telegram.enabled` - Enable Telegram bot (default: false)
+- `telegram.api_token` - Telegram Bot API token (supports `${TELEGRAM_BOT_TOKEN}`)
+
+### Telegram Bot
+
+The Telegram bot runs as a background task inside the daemon (`localgpt daemon start`). It provides the same chat capabilities as the CLI, including tool use and memory access.
+
+**Setup:**
+
+1. Create a bot via [@BotFather](https://t.me/BotFather) and get the API token
+2. Configure in `~/.localgpt/config.toml`:
+   ```toml
+   [telegram]
+   enabled = true
+   api_token = "${TELEGRAM_BOT_TOKEN}"
+   ```
+3. Start the daemon: `localgpt daemon start`
+4. Message your bot on Telegram — it will generate a 6-digit pairing code printed to the daemon console/logs
+5. Send the code back to the bot to complete pairing
+
+**Pairing & Auth:**
+- First message triggers a one-time pairing flow with a 6-digit code
+- Code is printed to stdout and daemon logs
+- Only the paired user can interact with the bot
+- Pairing persists in `~/.localgpt/telegram_paired_user.json`
+
+**Telegram Commands:**
+- `/help` - Show available commands
+- `/new` - Start fresh session
+- `/skills` - List available skills
+- `/model [name]` - Show or switch model
+- `/compact` - Compact session history
+- `/clear` - Clear session history
+- `/memory <query>` - Search memory files
+- `/status` - Show session info
+- `/unpair` - Remove pairing (re-enables pairing flow)
+
+**Implementation notes:**
+- Uses agent ID `"telegram"` (separate sessions from CLI's `"main"`)
+- Messages >4096 chars are split into chunks for Telegram's limit
+- Streaming responses are shown via debounced message edits (every 2s)
+- Tool calls are displayed with extracted details during streaming
+- Shares `TurnGate` concurrency control with HTTP server and heartbeat
 
 ### Workspace Path Customization (OpenClaw-Compatible)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "aquamarine"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
+dependencies = [
+ "include_dir",
+ "itertools 0.10.5",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +830,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,8 +1024,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -1011,12 +1053,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.114",
 ]
@@ -1047,6 +1114,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,7 +1138,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -1075,6 +1152,27 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1179,6 +1277,22 @@ name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "dptree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db96968fcf52fe063a98c75df1d1f2b1fba304e7ae29b72fdc81c1165b7e2fd0"
+dependencies = [
+ "colored",
+ "futures",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecolor"
@@ -1422,6 +1536,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erasable"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437cfb75878119ed8265685c41a115724eae43fb7cc5a0bf0e4ecc3b803af1c4"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "errno"
@@ -1976,7 +2100,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1993,6 +2117,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2047,6 +2177,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,7 +2200,7 @@ dependencies = [
  "libc",
  "log",
  "native-tls",
- "rand",
+ "rand 0.9.2",
  "reqwest",
  "serde",
  "serde_json",
@@ -2424,6 +2560,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2431,6 +2597,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2507,6 +2675,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2783,6 +2960,7 @@ dependencies = [
  "notify",
  "notify-debouncer-mini",
  "once_cell",
+ "rand 0.8.5",
  "regex",
  "reqwest",
  "rusqlite",
@@ -2794,6 +2972,7 @@ dependencies = [
  "sha2",
  "shellexpand",
  "sqlite-vec",
+ "teloxide",
  "tempfile",
  "thiserror 2.0.18",
  "tiktoken-rs",
@@ -3049,7 +3228,7 @@ dependencies = [
  "cfg_aliases 0.1.1",
  "codespan-reporting",
  "hexf-parse",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "rustc-hash 1.1.0",
  "spirv",
@@ -3254,6 +3433,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -3604,6 +3789,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3913,6 +4107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3991,6 +4191,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4016,6 +4237,16 @@ checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -4078,12 +4309,33 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4093,7 +4345,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -4132,8 +4393,8 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
  "v_frame",
@@ -4199,6 +4460,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rc-box"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897fecc9fac6febd4408f9e935e86df739b0023b625e610e0357535b9c8adad0"
+dependencies = [
+ "erasable",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4234,6 +4504,26 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4293,6 +4583,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -4319,6 +4610,9 @@ name = "rgb"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "ring"
@@ -4538,6 +4832,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4648,12 +4966,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -4882,6 +5231,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stacker"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4959,6 +5321,88 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "takecell"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20f34339676cdcab560c9a82300c4c2581f68b9369aedf0fae86f2ff9565ff3e"
+
+[[package]]
+name = "teloxide"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84992abeed3ae42e8401b25d266d12bcba1def0abe59d22f6b9781167545f71e"
+dependencies = [
+ "aquamarine",
+ "bytes",
+ "derive_more",
+ "dptree",
+ "either",
+ "futures",
+ "log",
+ "mime",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "teloxide-core",
+ "teloxide-macros",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "teloxide-core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7a34ca8e971fa892e633858c07547fe138ef4a02e4a4eaa1d35e517d6e0bc4"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "chrono",
+ "derive_more",
+ "either",
+ "futures",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project",
+ "rc-box",
+ "reqwest",
+ "rgb",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "stacker",
+ "take_mut",
+ "takecell",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "teloxide-macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300fadcaf0c182f19b5ca10bf23a45dc9a48925f00c704405fd90ee2c03942f9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5069,6 +5513,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5097,7 +5572,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand",
+ "rand 0.9.2",
  "rayon",
  "rayon-cond",
  "regex",
@@ -5231,7 +5706,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -5245,7 +5720,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
@@ -5411,7 +5886,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.2",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -5561,6 +6036,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -5966,7 +6442,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cfg_aliases 0.1.1",
  "document-features",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "naga",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,10 @@ base64 = "0.22"
 regex = "1"
 once_cell = "1"
 fs2 = "0.4"
+rand = "0.8"
+
+# Telegram bot
+teloxide = { version = "0.17", features = ["macros"] }
 
 # Desktop GUI (optional — disable with --no-default-features for headless builds)
 eframe = { version = "0.30", optional = true, default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A local device focused AI assistant built in Rust — persistent memory, autonom
 - **Local device focused** — runs entirely on your machine, your memory data stays yours
 - **Persistent memory** — markdown-based knowledge store with full-text and semantic search
 - **Autonomous heartbeat** — delegate tasks and let it work in the background
-- **Multiple interfaces** — CLI, web UI, desktop GUI
+- **Multiple interfaces** — CLI, web UI, desktop GUI, Telegram bot
 - **Multiple LLM providers** — Anthropic (Claude), OpenAI, Ollama
 - **OpenClaw compatible** — works with SOUL, MEMORY, HEARTBEAT markdown files and skills format
 
@@ -76,7 +76,23 @@ active_hours = { start = "09:00", end = "22:00" }
 
 [memory]
 workspace = "~/.localgpt/workspace"
+
+# Optional: Telegram bot
+[telegram]
+enabled = true
+api_token = "${TELEGRAM_BOT_TOKEN}"
 ```
+
+## Telegram Bot
+
+Access LocalGPT from Telegram with full chat, tool use, and memory support.
+
+1. Create a bot via [@BotFather](https://t.me/BotFather) and get the API token
+2. Set `TELEGRAM_BOT_TOKEN` or add the token to `config.toml`
+3. Start the daemon: `localgpt daemon start`
+4. Message your bot — enter the 6-digit pairing code shown in the daemon logs
+
+Once paired, use `/help` in Telegram to see available commands.
 
 ## CLI Commands
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -121,6 +121,12 @@ port = 31327
 # Bind address (127.0.0.1 for localhost only)
 bind = "127.0.0.1"
 
+# Telegram bot (optional)
+# Create a bot via @BotFather on Telegram to get an API token
+# [telegram]
+# enabled = true
+# api_token = "${TELEGRAM_BOT_TOKEN}"
+
 [logging]
 # Log level: trace, debug, info, warn, error
 level = "info"

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -511,26 +511,10 @@ async fn handle_command(
         "/quit" | "/exit" | "/q" => CommandResult::Quit,
 
         "/help" | "/h" | "/?" => {
-            println!("\nCommands:");
-            println!("  /help, /h, /?     - Show this help");
-            println!("  /quit, /exit, /q  - Exit chat");
-            println!("  /new              - Start a fresh session (reloads memory context)");
-            println!("  /skills           - List available skills");
-            println!("  /sessions         - List available sessions");
-            println!("  /search <query>   - Search across all sessions");
-            println!("  /resume <id>      - Resume a specific session");
-            println!("  /model [name]     - Show or switch model (e.g., /model gpt-4o)");
-            println!("  /models           - List available model prefixes");
-            println!("  /context          - Show context window usage");
-            println!("  /export [file]    - Export session as markdown");
-            println!("  /attach <file>    - Attach file to next message");
-            println!("  /attachments      - List pending attachments");
-            println!("  /compact          - Compact session history");
-            println!("  /clear            - Clear session history (keeps context)");
-            println!("  /memory <query>   - Search memory");
-            println!("  /reindex          - Rebuild memory index");
-            println!("  /save             - Save current session");
-            println!("  /status           - Show session status and API token usage");
+            println!(
+                "\n{}",
+                localgpt::commands::format_help_text(localgpt::commands::Interface::Cli)
+            );
 
             // Show skill commands if any
             let invocable: Vec<&Skill> = skills.iter().filter(|s| s.can_invoke()).collect();

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,199 @@
+//! Unified slash command definitions shared across CLI and Telegram interfaces.
+
+/// Which interfaces support a command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Interface {
+    Cli,
+    Telegram,
+}
+
+/// A slash command definition.
+pub struct SlashCommand {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub aliases: &'static [&'static str],
+    pub usage: &'static str,
+    pub interfaces: &'static [Interface],
+}
+
+impl SlashCommand {
+    pub fn supports(&self, iface: Interface) -> bool {
+        self.interfaces.contains(&iface)
+    }
+
+    /// Format as a help line, e.g. "  /help, /h, /?     - Show this help"
+    fn help_line(&self) -> String {
+        let mut names = format!("/{}", self.name);
+        for alias in self.aliases {
+            names.push_str(&format!(", /{}", alias));
+        }
+        if !self.usage.is_empty() {
+            names.push_str(&format!(" {}", self.usage));
+        }
+        format!("  {:<20}- {}", names, self.description)
+    }
+}
+
+pub const COMMANDS: &[SlashCommand] = &[
+    SlashCommand {
+        name: "help",
+        description: "Show available commands",
+        aliases: &["h", "?"],
+        usage: "",
+        interfaces: &[Interface::Cli, Interface::Telegram],
+    },
+    SlashCommand {
+        name: "quit",
+        description: "Exit chat",
+        aliases: &["exit", "q"],
+        usage: "",
+        interfaces: &[Interface::Cli],
+    },
+    SlashCommand {
+        name: "new",
+        description: "Start a fresh session",
+        aliases: &[],
+        usage: "",
+        interfaces: &[Interface::Cli, Interface::Telegram],
+    },
+    SlashCommand {
+        name: "skills",
+        description: "List available skills",
+        aliases: &[],
+        usage: "",
+        interfaces: &[Interface::Cli, Interface::Telegram],
+    },
+    SlashCommand {
+        name: "sessions",
+        description: "List saved sessions",
+        aliases: &[],
+        usage: "",
+        interfaces: &[Interface::Cli],
+    },
+    SlashCommand {
+        name: "search",
+        description: "Search across sessions",
+        aliases: &[],
+        usage: "<query>",
+        interfaces: &[Interface::Cli],
+    },
+    SlashCommand {
+        name: "resume",
+        description: "Resume a session",
+        aliases: &[],
+        usage: "<id>",
+        interfaces: &[Interface::Cli],
+    },
+    SlashCommand {
+        name: "model",
+        description: "Show or switch model",
+        aliases: &[],
+        usage: "[name]",
+        interfaces: &[Interface::Cli, Interface::Telegram],
+    },
+    SlashCommand {
+        name: "models",
+        description: "List model prefixes",
+        aliases: &[],
+        usage: "",
+        interfaces: &[Interface::Cli],
+    },
+    SlashCommand {
+        name: "context",
+        description: "Show context window usage",
+        aliases: &[],
+        usage: "",
+        interfaces: &[Interface::Cli],
+    },
+    SlashCommand {
+        name: "export",
+        description: "Export session as markdown",
+        aliases: &[],
+        usage: "[file]",
+        interfaces: &[Interface::Cli],
+    },
+    SlashCommand {
+        name: "attach",
+        description: "Attach file to message",
+        aliases: &[],
+        usage: "<file>",
+        interfaces: &[Interface::Cli],
+    },
+    SlashCommand {
+        name: "attachments",
+        description: "List pending attachments",
+        aliases: &[],
+        usage: "",
+        interfaces: &[Interface::Cli],
+    },
+    SlashCommand {
+        name: "compact",
+        description: "Compact session history",
+        aliases: &[],
+        usage: "",
+        interfaces: &[Interface::Cli, Interface::Telegram],
+    },
+    SlashCommand {
+        name: "clear",
+        description: "Clear session history",
+        aliases: &[],
+        usage: "",
+        interfaces: &[Interface::Cli, Interface::Telegram],
+    },
+    SlashCommand {
+        name: "memory",
+        description: "Search memory files",
+        aliases: &[],
+        usage: "<query>",
+        interfaces: &[Interface::Cli, Interface::Telegram],
+    },
+    SlashCommand {
+        name: "reindex",
+        description: "Rebuild memory index",
+        aliases: &[],
+        usage: "",
+        interfaces: &[Interface::Cli],
+    },
+    SlashCommand {
+        name: "save",
+        description: "Save current session",
+        aliases: &[],
+        usage: "",
+        interfaces: &[Interface::Cli],
+    },
+    SlashCommand {
+        name: "status",
+        description: "Show session info",
+        aliases: &[],
+        usage: "",
+        interfaces: &[Interface::Cli, Interface::Telegram],
+    },
+    SlashCommand {
+        name: "unpair",
+        description: "Unpair Telegram account",
+        aliases: &[],
+        usage: "",
+        interfaces: &[Interface::Telegram],
+    },
+];
+
+/// Format help text for a given interface.
+pub fn format_help_text(iface: Interface) -> String {
+    let mut lines = vec!["Commands:".to_string()];
+    for cmd in COMMANDS {
+        if cmd.supports(iface) {
+            lines.push(cmd.help_line());
+        }
+    }
+    lines.join("\n")
+}
+
+/// Build a list of `teloxide::types::BotCommand` for Telegram's setMyCommands.
+pub fn telegram_bot_commands() -> Vec<teloxide::types::BotCommand> {
+    use teloxide::types::BotCommand;
+    COMMANDS
+        .iter()
+        .filter(|cmd| cmd.supports(Interface::Telegram))
+        .map(|cmd| BotCommand::new(cmd.name, cmd.description))
+        .collect()
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -31,6 +31,9 @@ pub struct Config {
 
     #[serde(default)]
     pub tools: ToolsConfig,
+
+    #[serde(default)]
+    pub telegram: Option<TelegramConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -217,6 +220,14 @@ pub struct LoggingConfig {
     /// Days to keep log files (0 = keep forever, no auto-deletion)
     #[serde(default)]
     pub retention_days: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelegramConfig {
+    #[serde(default)]
+    pub enabled: bool,
+
+    pub api_token: String,
 }
 
 // Default value functions
@@ -449,6 +460,9 @@ impl Config {
         if let Some(ref mut anthropic) = self.providers.anthropic {
             anthropic.api_key = expand_env(&anthropic.api_key);
         }
+        if let Some(ref mut telegram) = self.telegram {
+            telegram.api_token = expand_env(&telegram.api_token);
+        }
     }
 
     pub fn get_value(&self, key: &str) -> Result<String> {
@@ -584,4 +598,9 @@ bind = "127.0.0.1"
 
 [logging]
 level = "info"
+
+# Telegram bot (optional)
+# [telegram]
+# enabled = true
+# api_token = "${TELEGRAM_BOT_TOKEN}"
 "#;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //! - Desktop GUI (egui-based)
 
 pub mod agent;
+pub mod commands;
 pub mod concurrency;
 pub mod config;
 #[cfg(feature = "desktop")]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,4 +1,5 @@
 mod http;
+pub mod telegram;
 mod websocket;
 
 pub use http::Server;

--- a/src/server/telegram.rs
+++ b/src/server/telegram.rs
@@ -1,0 +1,633 @@
+//! Telegram bot interface for LocalGPT
+//!
+//! Provides a Telegram bot that allows interacting with LocalGPT remotely.
+//! Uses a one-time pairing code mechanism to restrict access to the owner.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+use teloxide::prelude::*;
+use teloxide::types::MessageId;
+use tokio::sync::Mutex;
+use tracing::{debug, error, info, warn};
+
+use crate::agent::{extract_tool_detail, Agent, AgentConfig, StreamEvent};
+use crate::concurrency::TurnGate;
+use crate::config::Config;
+use crate::memory::MemoryManager;
+
+/// Agent ID for Telegram sessions
+const TELEGRAM_AGENT_ID: &str = "telegram";
+
+/// Maximum Telegram message length
+const MAX_MESSAGE_LENGTH: usize = 4096;
+
+/// Debounce interval for message edits (seconds)
+const EDIT_DEBOUNCE_SECS: u64 = 2;
+
+/// Pairing file relative to state dir
+const PAIRING_FILE: &str = "telegram_paired_user.json";
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PairedUser {
+    user_id: u64,
+    username: Option<String>,
+    paired_at: String,
+}
+
+struct SessionEntry {
+    agent: Agent,
+    last_accessed: Instant,
+}
+
+struct BotState {
+    config: Config,
+    sessions: Mutex<HashMap<i64, SessionEntry>>,
+    memory: MemoryManager,
+    turn_gate: TurnGate,
+    paired_user: Mutex<Option<PairedUser>>,
+    pending_pairing_code: Mutex<Option<String>>,
+}
+
+fn pairing_file_path() -> Result<PathBuf> {
+    let state_dir = crate::agent::get_state_dir()?;
+    Ok(state_dir.join(PAIRING_FILE))
+}
+
+fn load_paired_user() -> Option<PairedUser> {
+    let path = pairing_file_path().ok()?;
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn save_paired_user(user: &PairedUser) -> Result<()> {
+    let path = pairing_file_path()?;
+    let content = serde_json::to_string_pretty(user)?;
+    std::fs::write(path, content)?;
+    Ok(())
+}
+
+fn generate_pairing_code() -> String {
+    use rand::Rng;
+    let mut rng = rand::thread_rng();
+    format!("{:06}", rng.gen_range(100000..999999u32))
+}
+
+pub async fn run_telegram_bot(config: &Config, turn_gate: TurnGate) -> Result<()> {
+    let telegram_config = config
+        .telegram
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("Telegram config not found"))?;
+
+    if !telegram_config.enabled {
+        return Ok(());
+    }
+
+    let token = &telegram_config.api_token;
+    if token.is_empty() || token.starts_with("${") {
+        anyhow::bail!("Telegram API token not configured or not expanded");
+    }
+
+    let bot = Bot::new(token);
+
+    let memory =
+        MemoryManager::new_with_full_config(&config.memory, Some(config), TELEGRAM_AGENT_ID)?;
+
+    let paired_user = load_paired_user();
+    if let Some(ref user) = paired_user {
+        info!(
+            "Telegram bot: paired with user {} (ID: {})",
+            user.username.as_deref().unwrap_or("unknown"),
+            user.user_id
+        );
+    } else {
+        info!("Telegram bot: no paired user. Send any message to start pairing.");
+    }
+
+    let state = Arc::new(BotState {
+        config: config.clone(),
+        sessions: Mutex::new(HashMap::new()),
+        memory,
+        turn_gate,
+        paired_user: Mutex::new(paired_user),
+        pending_pairing_code: Mutex::new(None),
+    });
+
+    // Register bot commands so Telegram clients show the "/" menu
+    let commands = crate::commands::telegram_bot_commands();
+    if let Err(e) = bot.set_my_commands(commands).await {
+        warn!("Failed to set bot commands: {}", e);
+    }
+
+    info!("Starting Telegram bot...");
+
+    let handler = Update::filter_message().endpoint(handle_message);
+
+    Dispatcher::builder(bot, handler)
+        .default_handler(|_upd| async {})
+        .dependencies(dptree::deps![state])
+        .enable_ctrlc_handler()
+        .build()
+        .dispatch()
+        .await;
+
+    Ok(())
+}
+
+async fn handle_message(bot: Bot, msg: Message, state: Arc<BotState>) -> ResponseResult<()> {
+    let text = match msg.text() {
+        Some(t) => t.to_string(),
+        None => return Ok(()),
+    };
+
+    let user = match msg.from {
+        Some(ref u) => u,
+        None => return Ok(()),
+    };
+
+    let user_id = user.id.0;
+    let chat_id = msg.chat.id;
+
+    // Check pairing
+    {
+        let paired = state.paired_user.lock().await;
+        if let Some(ref pu) = *paired {
+            if pu.user_id != user_id {
+                bot.send_message(chat_id, "Not authorized. This bot is paired with another user.")
+                    .await?;
+                return Ok(());
+            }
+        } else {
+            // Not paired yet - handle pairing flow
+            drop(paired);
+            return handle_pairing(bot, msg, &state, user_id, &text).await;
+        }
+    }
+
+    // Handle slash commands
+    if text.starts_with('/') {
+        return handle_command(&bot, chat_id, &state, &text).await;
+    }
+
+    // Regular chat message
+    handle_chat(&bot, chat_id, &state, &text).await
+}
+
+async fn handle_pairing(
+    bot: Bot,
+    msg: Message,
+    state: &Arc<BotState>,
+    user_id: u64,
+    text: &str,
+) -> ResponseResult<()> {
+    let chat_id = msg.chat.id;
+    let mut pending = state.pending_pairing_code.lock().await;
+
+    if let Some(ref code) = *pending {
+        // User is entering the pairing code
+        if text.trim() == code.as_str() {
+            // Pairing successful
+            let username = msg.from.as_ref().and_then(|u| u.username.clone());
+            let paired = PairedUser {
+                user_id,
+                username: username.clone(),
+                paired_at: chrono::Utc::now().to_rfc3339(),
+            };
+
+            if let Err(e) = save_paired_user(&paired) {
+                error!("Failed to save pairing: {}", e);
+                bot.send_message(chat_id, "Pairing failed (could not save). Check logs.")
+                    .await?;
+                return Ok(());
+            }
+
+            *state.paired_user.lock().await = Some(paired);
+            *pending = None;
+
+            info!(
+                "Telegram bot: paired with user {} (ID: {})",
+                username.as_deref().unwrap_or("unknown"),
+                user_id
+            );
+
+            bot.send_message(
+                chat_id,
+                "Paired successfully! You can now chat with LocalGPT.\n\nUse /new to start a fresh session, /status to see session info.",
+            )
+            .await?;
+        } else {
+            bot.send_message(chat_id, "Invalid pairing code. Please try again.")
+                .await?;
+        }
+    } else {
+        // Generate new pairing code
+        let code = generate_pairing_code();
+        println!("\n========================================");
+        println!("  TELEGRAM PAIRING CODE: {}", code);
+        println!("========================================\n");
+        info!("Telegram pairing code generated for user {} (ID: {})",
+            msg.from.as_ref().and_then(|u| u.username.as_deref()).unwrap_or("unknown"),
+            user_id
+        );
+
+        *pending = Some(code);
+
+        bot.send_message(
+            chat_id,
+            "Welcome! A pairing code has been printed to the daemon logs/stdout.\nPlease enter the code to pair this bot with your account.",
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+async fn handle_command(
+    bot: &Bot,
+    chat_id: ChatId,
+    state: &Arc<BotState>,
+    text: &str,
+) -> ResponseResult<()> {
+    let parts: Vec<&str> = text.splitn(2, ' ').collect();
+    let cmd = parts[0];
+    let args = parts.get(1).map(|s| s.trim()).unwrap_or("");
+
+    match cmd {
+        "/start" | "/help" => {
+            let help = format!(
+                "LocalGPT Telegram Bot\n\n{}",
+                crate::commands::format_help_text(crate::commands::Interface::Telegram)
+            );
+            bot.send_message(chat_id, help).await?;
+        }
+        "/new" => {
+            let mut sessions = state.sessions.lock().await;
+            sessions.remove(&chat_id.0);
+            bot.send_message(
+                chat_id,
+                "Session cleared. Send a message to start a new conversation.",
+            )
+            .await?;
+        }
+        "/status" => {
+            let sessions = state.sessions.lock().await;
+            let status_text = if let Some(entry) = sessions.get(&chat_id.0) {
+                let status = entry.agent.session_status();
+                let (used, usable, total) = entry.agent.context_usage();
+                format!(
+                    "Session active\n\
+                     Model: {}\n\
+                     Messages: {}\n\
+                     Tokens: {} / {} (window: {})\n\
+                     Compactions: {}\n\
+                     Idle: {}s",
+                    entry.agent.model(),
+                    status.message_count,
+                    used,
+                    usable,
+                    total,
+                    status.compaction_count,
+                    entry.last_accessed.elapsed().as_secs()
+                )
+            } else {
+                "No active session. Send a message to start one.".to_string()
+            };
+            bot.send_message(chat_id, status_text).await?;
+        }
+        "/compact" => {
+            let mut sessions = state.sessions.lock().await;
+            match sessions.get_mut(&chat_id.0) {
+                Some(entry) => {
+                    entry.last_accessed = Instant::now();
+                    match entry.agent.compact_session().await {
+                        Ok((before, after)) => {
+                            bot.send_message(
+                                chat_id,
+                                format!("Compacted: {} -> {} tokens", before, after),
+                            )
+                            .await?;
+                        }
+                        Err(e) => {
+                            bot.send_message(chat_id, format!("Compact failed: {}", e))
+                                .await?;
+                        }
+                    }
+                }
+                None => {
+                    bot.send_message(chat_id, "No active session.").await?;
+                }
+            }
+        }
+        "/clear" => {
+            let mut sessions = state.sessions.lock().await;
+            if let Some(entry) = sessions.get_mut(&chat_id.0) {
+                entry.agent.clear_session();
+                entry.last_accessed = Instant::now();
+                bot.send_message(chat_id, "Session history cleared.")
+                    .await?;
+            } else {
+                bot.send_message(chat_id, "No active session.").await?;
+            }
+        }
+        "/memory" => {
+            if args.is_empty() {
+                bot.send_message(chat_id, "Usage: /memory <search query>")
+                    .await?;
+            } else {
+                match state.memory.search(args, 5) {
+                    Ok(results) => {
+                        if results.is_empty() {
+                            bot.send_message(chat_id, "No results found.").await?;
+                        } else {
+                            let mut text = format!("Memory search: \"{}\"\n\n", args);
+                            for (i, r) in results.iter().enumerate() {
+                                text.push_str(&format!(
+                                    "{}. {} (L{}-{})\n{}\n\n",
+                                    i + 1,
+                                    r.file,
+                                    r.line_start,
+                                    r.line_end,
+                                    truncate_str(&r.content, 300),
+                                ));
+                            }
+                            send_long_message(bot, chat_id, None, &text).await;
+                        }
+                    }
+                    Err(e) => {
+                        bot.send_message(chat_id, format!("Search error: {}", e))
+                            .await?;
+                    }
+                }
+            }
+        }
+        "/model" => {
+            if args.is_empty() {
+                let sessions = state.sessions.lock().await;
+                let current = sessions
+                    .get(&chat_id.0)
+                    .map(|e| e.agent.model().to_string())
+                    .unwrap_or_else(|| state.config.agent.default_model.clone());
+                bot.send_message(chat_id, format!("Current model: {}\n\nUsage: /model <name>", current))
+                    .await?;
+            } else {
+                let mut sessions = state.sessions.lock().await;
+                if let Some(entry) = sessions.get_mut(&chat_id.0) {
+                    match entry.agent.set_model(args) {
+                        Ok(()) => {
+                            bot.send_message(chat_id, format!("Switched to model: {}", args))
+                                .await?;
+                        }
+                        Err(e) => {
+                            bot.send_message(chat_id, format!("Failed to switch model: {}", e))
+                                .await?;
+                        }
+                    }
+                } else {
+                    bot.send_message(
+                        chat_id,
+                        "No active session. Send a message first, then switch models.",
+                    )
+                    .await?;
+                }
+            }
+        }
+        "/skills" => {
+            let workspace_path = state.config.workspace_path();
+            match crate::agent::load_skills(&workspace_path) {
+                Ok(skills) => {
+                    if skills.is_empty() {
+                        bot.send_message(chat_id, "No skills installed.")
+                            .await?;
+                    } else {
+                        let summary = crate::agent::get_skills_summary(&skills);
+                        bot.send_message(chat_id, summary).await?;
+                    }
+                }
+                Err(e) => {
+                    bot.send_message(chat_id, format!("Failed to load skills: {}", e))
+                        .await?;
+                }
+            }
+        }
+        "/unpair" => {
+            *state.paired_user.lock().await = None;
+            if let Ok(path) = pairing_file_path() {
+                let _ = std::fs::remove_file(path);
+            }
+            let mut sessions = state.sessions.lock().await;
+            sessions.remove(&chat_id.0);
+            info!("Telegram bot: user unpaired");
+            bot.send_message(chat_id, "Unpaired. Send any message to start a new pairing.")
+                .await?;
+        }
+        _ => {
+            bot.send_message(chat_id, "Unknown command. Use /help for available commands.")
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn truncate_str(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        s
+    } else {
+        // Find a char boundary
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        &s[..end]
+    }
+}
+
+async fn handle_chat(
+    bot: &Bot,
+    chat_id: ChatId,
+    state: &Arc<BotState>,
+    text: &str,
+) -> ResponseResult<()> {
+    // Send initial "thinking" message
+    let thinking_msg = bot
+        .send_message(chat_id, "Thinking...")
+        .await?;
+    let msg_id = thinking_msg.id;
+
+    // Acquire turn gate
+    let _gate_permit = state.turn_gate.acquire().await;
+
+    // Get or create agent session, then stream response
+    let mut sessions = state.sessions.lock().await;
+
+    if !sessions.contains_key(&chat_id.0) {
+        let agent_config = AgentConfig {
+            model: state.config.agent.default_model.clone(),
+            context_window: state.config.agent.context_window,
+            reserve_tokens: state.config.agent.reserve_tokens,
+        };
+
+        match Agent::new(agent_config, &state.config, state.memory.clone()).await {
+            Ok(mut agent) => {
+                if let Err(e) = agent.new_session().await {
+                    error!("Failed to create session: {}", e);
+                    let _ = bot
+                        .edit_message_text(chat_id, msg_id, format!("Error: {}", e))
+                        .await;
+                    return Ok(());
+                }
+                sessions.insert(
+                    chat_id.0,
+                    SessionEntry {
+                        agent,
+                        last_accessed: Instant::now(),
+                    },
+                );
+            }
+            Err(e) => {
+                error!("Failed to create agent: {}", e);
+                let _ = bot
+                    .edit_message_text(chat_id, msg_id, format!("Error: {}", e))
+                    .await;
+                return Ok(());
+            }
+        }
+    }
+
+    let entry = sessions.get_mut(&chat_id.0).unwrap();
+    entry.last_accessed = Instant::now();
+
+    // Use streaming with tools
+    let response = match entry.agent.chat_stream_with_tools(text).await {
+        Ok(event_stream) => {
+            use futures::StreamExt;
+
+            let mut full_response = String::new();
+            let mut last_edit = Instant::now();
+            let mut pinned_stream = std::pin::pin!(event_stream);
+            let mut tool_info = String::new();
+
+            while let Some(event) = pinned_stream.next().await {
+                match event {
+                    Ok(StreamEvent::Content(delta)) => {
+                        full_response.push_str(&delta);
+
+                        // Debounced edit
+                        if last_edit.elapsed().as_secs() >= EDIT_DEBOUNCE_SECS {
+                            let display = format_display(&full_response, &tool_info);
+                            let _ = bot
+                                .edit_message_text(chat_id, msg_id, &display)
+                                .await;
+                            last_edit = Instant::now();
+                        }
+                    }
+                    Ok(StreamEvent::ToolCallStart {
+                        name, arguments, ..
+                    }) => {
+                        let detail = extract_tool_detail(&name, &arguments);
+                        let info_line = if let Some(d) = detail {
+                            format!("🔧 {}({})\n", name, d)
+                        } else {
+                            format!("🔧 {}\n", name)
+                        };
+                        tool_info.push_str(&info_line);
+
+                        let display = format_display(&full_response, &tool_info);
+                        let _ = bot
+                            .edit_message_text(chat_id, msg_id, &display)
+                            .await;
+                        last_edit = Instant::now();
+                    }
+                    Ok(StreamEvent::ToolCallEnd { .. }) => {}
+                    Ok(StreamEvent::Done) => break,
+                    Err(e) => {
+                        error!("Stream error: {}", e);
+                        full_response.push_str(&format!("\n\nError: {}", e));
+                        break;
+                    }
+                }
+            }
+
+            if full_response.is_empty() {
+                "(no response)".to_string()
+            } else {
+                full_response
+            }
+        }
+        Err(e) => format!("Error: {}", e),
+    };
+
+    // Save session before releasing lock
+    if let Err(e) = entry.agent.save_session_for_agent(TELEGRAM_AGENT_ID).await {
+        debug!("Failed to save telegram session: {}", e);
+    }
+
+    drop(sessions);
+
+    // Final edit with complete response
+    send_long_message(bot, chat_id, Some(msg_id), &response).await;
+
+    Ok(())
+}
+
+fn format_display(response: &str, tool_info: &str) -> String {
+    let mut display = String::new();
+    if !tool_info.is_empty() {
+        display.push_str(tool_info);
+        display.push('\n');
+    }
+    display.push_str(response);
+
+    // Truncate for Telegram limit
+    if display.len() > MAX_MESSAGE_LENGTH {
+        display.truncate(MAX_MESSAGE_LENGTH - 3);
+        display.push_str("...");
+    }
+
+    display
+}
+
+async fn send_long_message(
+    bot: &Bot,
+    chat_id: ChatId,
+    edit_msg_id: Option<MessageId>,
+    text: &str,
+) {
+    if text.len() <= MAX_MESSAGE_LENGTH {
+        if let Some(msg_id) = edit_msg_id {
+            let _ = bot.edit_message_text(chat_id, msg_id, text).await;
+        } else {
+            let _ = bot.send_message(chat_id, text).await;
+        }
+        return;
+    }
+
+    // Split into chunks at char boundaries
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    while start < text.len() {
+        let mut end = (start + MAX_MESSAGE_LENGTH).min(text.len());
+        while end > start && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        chunks.push(&text[start..end]);
+        start = end;
+    }
+
+    // First chunk: edit existing message or send new
+    if let Some(first) = chunks.first() {
+        if let Some(msg_id) = edit_msg_id {
+            let _ = bot.edit_message_text(chat_id, msg_id, *first).await;
+        } else {
+            let _ = bot.send_message(chat_id, *first).await;
+        }
+    }
+
+    // Remaining chunks as new messages
+    for chunk in chunks.iter().skip(1) {
+        let _ = bot.send_message(chat_id, *chunk).await;
+    }
+}


### PR DESCRIPTION
Add a Telegram bot that runs as a background task in the daemon, providing the same chat capabilities as the CLI including tool use, memory access, streaming responses, and slash commands.

- One-time 6-digit pairing code auth flow (printed to daemon logs)
- Per-chat persistent sessions with agent ID "telegram"
- Streaming responses via debounced message edits (2s interval)
- Full slash command support: /help, /new, /model, /memory, /status, etc.
- Shared command definitions between CLI and Telegram (commands.rs)
- Teloxide 0.17 for current Telegram Bot API compatibility

Related: https://github.com/localgpt-app/localgpt/issues/3