### PR TITLE
feat(telegram): render agent responses as HTML with markdown conversion

### DIFF
--- a/src/agent/providers.rs
+++ b/src/agent/providers.rs
@@ -158,15 +158,13 @@ pub trait LLMProvider: Send + Sync {
         // Default implementation: single chunk with full response
         let resp = self.chat(messages, tools).await?;
         match resp.content {
-            LLMResponseContent::Text(text) => {
-                Ok(Box::pin(futures::stream::once(async move {
-                    Ok(StreamChunk {
-                        delta: text,
-                        done: true,
-                        tool_calls: None,
-                    })
-                })))
-            }
+            LLMResponseContent::Text(text) => Ok(Box::pin(futures::stream::once(async move {
+                Ok(StreamChunk {
+                    delta: text,
+                    done: true,
+                    tool_calls: None,
+                })
+            }))),
             LLMResponseContent::ToolCalls(calls) => {
                 Ok(Box::pin(futures::stream::once(async move {
                     Ok(StreamChunk {
@@ -1135,15 +1133,13 @@ impl LLMProvider for OllamaProvider {
         if tools.is_some() && tools.map(|t| !t.is_empty()).unwrap_or(false) {
             let resp = self.chat(messages, tools).await?;
             return match resp.content {
-                LLMResponseContent::Text(text) => {
-                    Ok(Box::pin(futures::stream::once(async move {
-                        Ok(StreamChunk {
-                            delta: text,
-                            done: true,
-                            tool_calls: None,
-                        })
-                    })))
-                }
+                LLMResponseContent::Text(text) => Ok(Box::pin(futures::stream::once(async move {
+                    Ok(StreamChunk {
+                        delta: text,
+                        done: true,
+                        tool_calls: None,
+                    })
+                }))),
                 LLMResponseContent::ToolCalls(calls) => {
                     Ok(Box::pin(futures::stream::once(async move {
                         Ok(StreamChunk {
@@ -1933,5 +1929,4 @@ mod tests {
             "custom-model".to_string()
         );
     }
-
 }

--- a/src/cli/daemon.rs
+++ b/src/cli/daemon.rs
@@ -180,17 +180,12 @@ async fn run_daemon_services(config: &Config, agent_id: &str) -> Result<()> {
     };
 
     // Spawn Telegram bot in background if configured
-    let telegram_handle = if config
-        .telegram
-        .as_ref()
-        .is_some_and(|t| t.enabled)
-    {
+    let telegram_handle = if config.telegram.as_ref().is_some_and(|t| t.enabled) {
         let tg_config = config.clone();
         let tg_gate = turn_gate.clone();
         println!("  Telegram: enabled");
         Some(tokio::spawn(async move {
-            if let Err(e) =
-                localgpt::server::telegram::run_telegram_bot(&tg_config, tg_gate).await
+            if let Err(e) = localgpt::server::telegram::run_telegram_bot(&tg_config, tg_gate).await
             {
                 tracing::error!("Telegram bot error: {}", e);
             }


### PR DESCRIPTION
Convert markdown from LLM responses to Telegram HTML format for proper rendering of bold, italic, code blocks, inline code, links, and headers. System messages use plain HTML escaping. Falls back to plain text if HTML conversion causes issues.