### PR TITLE
Add GLM (Z.AI) provider support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ LocalGPT is a local-only AI assistant with persistent markdown-based memory and 
 ### Core Modules (`src/`)
 
 - **agent/** - LLM interaction layer
-  - `providers.rs` - Trait `LLMProvider` with implementations for OpenAI, Anthropic, Ollama, and Claude CLI. Model prefix determines provider (`claude-cli/*` → Claude CLI, `gpt-*` → OpenAI, `claude-*` → Anthropic API, else Ollama)
+  - `providers.rs` - Trait `LLMProvider` with implementations for OpenAI, Anthropic, Ollama, Claude CLI, and GLM (Z.AI). Model prefix determines provider (`claude-cli/*` → Claude CLI, `gpt-*` → OpenAI, `claude-*` → Anthropic API, `glm-*` → GLM, else Ollama)
   - `session.rs` - Conversation state with automatic compaction when approaching context window limits
   - `session_store.rs` - Session metadata store (`sessions.json`) with CLI session ID persistence
   - `system_prompt.rs` - Builds system prompt with identity, safety, workspace info, tools, skills, and special tokens
@@ -76,7 +76,7 @@ Default config path: `~/.localgpt/config.toml` (see `config.example.toml`)
 **Auto-creation**: If no config file exists on first run, LocalGPT automatically creates a default config with helpful comments. If an OpenClaw config exists at `~/.openclaw/config.json5`, it will be migrated automatically.
 
 Key settings:
-- `agent.default_model` - Model name (determines provider). Default: `claude-cli/opus`
+- `agent.default_model` - Model name (determines provider). Default: `claude-cli/opus`. Supported: Anthropic (`anthropic/claude-*`), OpenAI (`openai/gpt-*`), GLM/Z.AI (`glm/glm-4.7` or alias `glm`), Claude CLI (`claude-cli/*`), Ollama (`ollama/*`)
 - `agent.context_window` / `reserve_tokens` - Context management
 - `memory.workspace` - Workspace directory path. Default: `~/.localgpt/workspace`
 - `heartbeat.interval` - Duration string (e.g., "30m", "1h")

--- a/config.example.toml
+++ b/config.example.toml
@@ -18,6 +18,9 @@
 # OpenAI API (requires OPENAI_API_KEY):
 #   - "openai/gpt-4o", "openai/gpt-4o-mini", "openai/gpt-4-turbo"
 #
+# GLM / Z.AI API (requires GLM API key):
+#   - "glm/glm-4.7" (or use alias "glm")
+#
 # Claude CLI (local, no API key needed):
 #   - "claude-cli/opus", "claude-cli/sonnet", "claude-cli/haiku"
 #
@@ -53,6 +56,12 @@ base_url = "https://api.anthropic.com"
 # [providers.claude_cli]
 # command = "claude"
 # model = "opus"  # opus, sonnet, or haiku
+
+# GLM / Z.AI configuration (optional)
+# Get your API key at: https://z.ai/manage-apikey/apikey-list
+# [providers.glm]
+# api_key = "${GLM_API_KEY}"
+# base_url = "https://api.z.ai/api/coding/paas/v4"
 
 [heartbeat]
 # Enable automatic heartbeat

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -115,6 +115,9 @@ pub struct ProvidersConfig {
 
     #[serde(default)]
     pub claude_cli: Option<ClaudeCliConfig>,
+
+    #[serde(default)]
+    pub glm: Option<GlmConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -149,6 +152,14 @@ pub struct ClaudeCliConfig {
 
     #[serde(default = "default_claude_cli_model")]
     pub model: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GlmConfig {
+    pub api_key: String,
+
+    #[serde(default = "default_glm_base_url")]
+    pub base_url: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -292,6 +303,9 @@ fn default_claude_cli_command() -> String {
 }
 fn default_claude_cli_model() -> String {
     "opus".to_string()
+}
+fn default_glm_base_url() -> String {
+    "https://api.z.ai/api/coding/paas/v4".to_string()
 }
 fn default_true() -> bool {
     true


### PR DESCRIPTION
Nice work on the app! Looks great, I wanted to add some GLM support since I have a yearly subscription to it

Notes:
- Add GLM provider in agent/providers.rs for glm-* models
- Extend config with glm/api_key and default_model alias
- Document GLM in config.example.toml and CLAUDE.md

Tested and works.