### PR TITLE
docs: document local OpenAI-compatible server setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,25 @@ enabled = true
 api_token = "${TELEGRAM_BOT_TOKEN}"
 ```
 
+### Using a local OpenAI-compatible server (LM Studio, llamafile, etc.)
+
+If you run a local server that speaks the OpenAI API (e.g., LM Studio, llamafile, vLLM), point LocalGPT at it and pick an `openai/*` model ID so it does **not** try to spawn the `claude` CLI:
+
+1. Start your server (LM Studio default port: `1234`; llamafile default: `8080`) and note its model name.
+2. Edit `~/.localgpt/config.toml`:
+   ```toml
+   [agent]
+   default_model = "openai/<your-model-name>"
+
+   [providers.openai]
+   # Many local servers accept a dummy key
+   api_key = "not-needed"
+   base_url = "http://127.0.0.1:8080/v1" # or http://127.0.0.1:1234/v1 for LM Studio
+   ```
+3. Run `localgpt chat` (or `localgpt daemon start`) and requests will go to your local server.
+
+Tip: If you see `Failed to spawn Claude CLI`, change `agent.default_model` away from `claude-cli/*` or install the `claude` CLI.
+
 ## Telegram Bot
 
 Access LocalGPT from Telegram with full chat, tool use, and memory support.

--- a/config.example.toml
+++ b/config.example.toml
@@ -45,6 +45,9 @@ base_url = "https://api.anthropic.com"
 # [providers.openai]
 # api_key = "${OPENAI_API_KEY}"
 # base_url = "https://api.openai.com/v1"
+# For local OpenAI-compatible servers (LM Studio, llamafile, vLLM):
+# api_key = "not-needed"
+# base_url = "http://127.0.0.1:8080/v1" # LM Studio default is http://127.0.0.1:1234/v1
 
 # Ollama configuration (for local models)
 # [providers.ollama]


### PR DESCRIPTION
## Summary
- add README instructions for pointing LocalGPT at local OpenAI-compatible servers like LM Studio or llamafile
- note config.example.toml snippet with base_url/api_key for local endpoints

## Rationale
- users running local servers (issue #17) hit "Failed to spawn Claude CLI" and need explicit guidance to use openai/* models with a local base URL

## Changes
- README: new section with step-by-step config for local servers and the Claude CLI fallback note
- config.example.toml: comment showing dummy API key and base_url for localhost endpoints

## Tests
- not run (docs-only)

Fixes #17