### PR TITLE
Improve Heartbeat Reliability

### DIFF
--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -358,6 +358,9 @@ pub struct HeartbeatConfig {
     #[serde(default = "default_interval")]
     pub interval: String,
 
+    #[serde(default = "default_overdue_delay")]
+    pub overdue_delay: String,
+
     #[serde(default)]
     pub active_hours: Option<ActiveHours>,
 
@@ -504,6 +507,10 @@ fn default_true() -> bool {
 fn default_interval() -> String {
     "30m".to_string()
 }
+
+fn default_overdue_delay() -> String {
+    "1m".to_string()
+}
 fn default_workspace() -> String {
     "~/.local/share/localgpt/workspace".to_string()
 }
@@ -607,6 +614,7 @@ impl Default for HeartbeatConfig {
         Self {
             enabled: default_true(),
             interval: default_interval(),
+            overdue_delay: default_overdue_delay(),
             active_hours: None,
             timezone: None,
         }

--- a/crates/core/src/heartbeat/events.rs
+++ b/crates/core/src/heartbeat/events.rs
@@ -13,6 +13,8 @@ pub enum HeartbeatStatus {
     Ok,
     /// Heartbeat was skipped (outside active hours, empty file, etc.)
     Skipped,
+    /// Heartbeat was skipped transiently (a soon retry may be useful)
+    SkippedMayTry,
     /// Heartbeat failed with an error
     Failed,
 }

--- a/crates/core/src/heartbeat/events.rs
+++ b/crates/core/src/heartbeat/events.rs
@@ -1,10 +1,10 @@
 //! Heartbeat event tracking for UI status display
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::sync::RwLock;
 
 /// Heartbeat event status
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum HeartbeatStatus {
     /// Heartbeat ran and sent a response
@@ -18,7 +18,7 @@ pub enum HeartbeatStatus {
 }
 
 /// A heartbeat event for tracking/display
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct HeartbeatEvent {
     /// Timestamp in milliseconds
     pub ts: u64,

--- a/crates/core/src/heartbeat/runner.rs
+++ b/crates/core/src/heartbeat/runner.rs
@@ -107,7 +107,13 @@ impl HeartbeatRunner {
         }
 
         // heartbeat is overdue
-        return self.interval / 2;
+        return parse_duration(&self.config.heartbeat.overdue_delay).map_or_else(
+            |e| {
+                warn!(name: "Heartbeat", "invalid overdue_delay: {}, falling back to zero", e);
+                Duration::ZERO
+            },
+            |d| d,
+        );
     }
 
     /// Run the heartbeat loop continuously

--- a/crates/core/src/heartbeat/runner.rs
+++ b/crates/core/src/heartbeat/runner.rs
@@ -5,7 +5,7 @@ use chrono::{Local, NaiveTime};
 use std::fs;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
-use tokio::time::sleep;
+use tokio::time::interval;
 use tracing::{debug, info, warn};
 
 use super::events::{HeartbeatEvent, HeartbeatStatus, emit_heartbeat_event, now_ms};
@@ -89,9 +89,13 @@ impl HeartbeatRunner {
     pub async fn run(&self) -> Result<()> {
         info!(name: "Heartbeat", "starting runner with interval: {:?}", self.interval);
 
+        let mut interval = interval(self.interval);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        interval.tick().await; // Consume first (immediate) tick
+
         loop {
-            // Sleep until next interval
-            sleep(self.interval).await;
+            interval.tick().await; // Sleep until next interval
 
             // Check active hours
             if !self.in_active_hours() {

--- a/crates/core/src/heartbeat/runner.rs
+++ b/crates/core/src/heartbeat/runner.rs
@@ -87,10 +87,7 @@ impl HeartbeatRunner {
 
     /// Run the heartbeat loop continuously
     pub async fn run(&self) -> Result<()> {
-        info!(
-            "Starting heartbeat runner with interval: {:?}",
-            self.interval
-        );
+        info!(name: "Heartbeat", "starting runner with interval: {:?}", self.interval);
 
         loop {
             // Sleep until next interval
@@ -98,7 +95,7 @@ impl HeartbeatRunner {
 
             // Check active hours
             if !self.in_active_hours() {
-                debug!("Outside active hours, skipping heartbeat");
+                info!(name: "Heartbeat", "skipping: outside active hours");
                 emit_heartbeat_event(HeartbeatEvent {
                     ts: now_ms(),
                     status: HeartbeatStatus::Skipped,
@@ -129,12 +126,13 @@ impl HeartbeatRunner {
                     });
 
                     if is_heartbeat_ok(&response) {
-                        debug!("Heartbeat: OK");
+                        debug!(name: "Heartbeat", "OK");
                     } else {
-                        info!("Heartbeat response: {}", response);
+                        warn!(name: "Heartbeat", "response not OK: {}", response);
                     }
                 }
                 Err(e) => {
+                    warn!(name: "Heartbeat", "error: {}", e);
                     let duration_ms = start.elapsed().as_millis() as u64;
                     emit_heartbeat_event(HeartbeatEvent {
                         ts: now_ms(),
@@ -143,7 +141,6 @@ impl HeartbeatRunner {
                         preview: None,
                         reason: Some(e.to_string()),
                     });
-                    warn!("Heartbeat error: {}", e);
                 }
             }
         }
@@ -192,7 +189,7 @@ impl HeartbeatRunner {
         if let Some(ref gate) = self.turn_gate
             && gate.is_busy()
         {
-            debug!("Skipping heartbeat: agent turn in flight (TurnGate busy)");
+            info!(name: "Heartbeat", "skipping: agent turn in flight (TurnGate busy)");
             return Ok((HEARTBEAT_OK_TOKEN.to_string(), HeartbeatStatus::Skipped));
         }
 
@@ -200,7 +197,7 @@ impl HeartbeatRunner {
         let _ws_guard = match self.workspace_lock.try_acquire()? {
             Some(guard) => guard,
             None => {
-                debug!("Skipping heartbeat: workspace locked by another process");
+                info!(name: "Heartbeat", "skipping: workspace locked by another process");
                 return Ok((HEARTBEAT_OK_TOKEN.to_string(), HeartbeatStatus::Skipped));
             }
         };
@@ -211,7 +208,7 @@ impl HeartbeatRunner {
             match gate.try_acquire() {
                 Some(permit) => Some(permit),
                 None => {
-                    debug!("Skipping heartbeat: agent turn started between check and acquire");
+                    info!(name: "Heartbeat", "skipping: agent turn started between check and acquire");
                     return Ok((HEARTBEAT_OK_TOKEN.to_string(), HeartbeatStatus::Skipped));
                 }
             }
@@ -223,13 +220,13 @@ impl HeartbeatRunner {
         let heartbeat_path = self.workspace.join("HEARTBEAT.md");
 
         if !heartbeat_path.exists() {
-            debug!("No HEARTBEAT.md found");
+            info!(name: "Heartbeat", "skipping: no HEARTBEAT.md");
             return Ok((HEARTBEAT_OK_TOKEN.to_string(), HeartbeatStatus::Skipped));
         }
 
         let content = fs::read_to_string(&heartbeat_path)?;
         if content.trim().is_empty() {
-            debug!("HEARTBEAT.md is empty");
+            info!(name: "Heartbeat", "skipping: empty HEARTBEAT.md");
             return Ok((HEARTBEAT_OK_TOKEN.to_string(), HeartbeatStatus::Skipped));
         }
 
@@ -242,6 +239,8 @@ impl HeartbeatRunner {
 
         let mut agent = Agent::new(agent_config, &self.config, self.memory.clone()).await?;
         agent.new_session().await?;
+
+        info!(name: "Heartbeat", "Running HEARTBEAT.md");
 
         // Check if workspace is a git repo
         let workspace_is_git = self.workspace.join(".git").exists();
@@ -263,8 +262,8 @@ impl HeartbeatRunner {
             if let Some(entry) = store.get(session_key)
                 && entry.is_duplicate_heartbeat(&response)
             {
-                debug!(
-                    "Skipping duplicate heartbeat (same text within 24h): {}",
+                info!(name: "Heartbeat",
+                    "skipping: duplicate (same text within 24h): {}",
                     &response[..response.len().min(100)]
                 );
                 return Ok((response, HeartbeatStatus::Skipped));
@@ -275,7 +274,7 @@ impl HeartbeatRunner {
             if let Err(e) = store.load_and_update(session_key, &session_id, |entry| {
                 entry.record_heartbeat(&response);
             }) {
-                warn!("Failed to record heartbeat in session store: {}", e);
+                warn!(name: "Heartbeat", "Failed to record in session store: {}", e);
             }
         }
 

--- a/crates/core/src/heartbeat/runner.rs
+++ b/crates/core/src/heartbeat/runner.rs
@@ -152,6 +152,14 @@ impl HeartbeatRunner {
                 }
             };
 
+            // Persist last heartbeat event to disk
+            if let Err(e) = serde_json::to_writer_pretty(
+                fs::File::create(self.config.paths.last_heartbeat())?,
+                &event,
+            ) {
+                warn!(name: "Heartbeat", "failed to write event: {}", e);
+            }
+
             emit_heartbeat_event(event);
 
             info!(name: "Heartbeat", "waiting for next tick");

--- a/crates/core/src/heartbeat/runner.rs
+++ b/crates/core/src/heartbeat/runner.rs
@@ -4,8 +4,8 @@ use anyhow::Result;
 use chrono::{Local, NaiveTime};
 use std::fs;
 use std::path::PathBuf;
-use std::time::{Duration, Instant};
-use tokio::time::interval;
+use std::time::{Duration, Instant, SystemTime};
+use tokio::time::interval_at;
 use tracing::{debug, info, warn};
 
 use super::events::{HeartbeatEvent, HeartbeatStatus, emit_heartbeat_event, now_ms};
@@ -85,14 +85,46 @@ impl HeartbeatRunner {
         })
     }
 
+    async fn first_delay(&self) -> Duration {
+        // Read last heartbeat event to calibrate first tick time
+        if let Ok(json) = fs::read_to_string(self.config.paths.last_heartbeat()) {
+            if let Ok(event) = serde_json::from_str::<HeartbeatEvent>(&json) {
+                let last_tick_end = std::time::UNIX_EPOCH + Duration::from_millis(event.ts as u64);
+                let last_tick_elapsed = Duration::from_millis(event.duration_ms as u64);
+                let last_tick = last_tick_end - last_tick_elapsed;
+                debug!(
+                    name: "Heartbeat",
+                    "loaded last_tick: {:?} (ts: {}, duration_ms: {})",
+                    last_tick, event.ts, event.duration_ms
+                );
+
+                let next_tick = last_tick + self.interval;
+                let now = SystemTime::now();
+                if now < next_tick {
+                    return next_tick.duration_since(now).unwrap_or(Duration::ZERO);
+                }
+            }
+        }
+
+        // heartbeat is overdue
+        return self.interval / 2;
+    }
+
     /// Run the heartbeat loop continuously
     pub async fn run(&self) -> Result<()> {
         info!(name: "Heartbeat", "starting runner with interval: {:?}", self.interval);
 
-        let mut interval = interval(self.interval);
+        // Schedule first tick at next interval from last tick
+        let first_after = self.first_delay().await;
+        let first_at = tokio::time::Instant::now() + first_after;
+        let mut interval = interval_at(first_at, self.interval);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
-        interval.tick().await; // Consume first (immediate) tick
+        info!(
+            name: "Heartbeat",
+            "first tick scheduled after: {:?} at: {:?}",
+            first_after,
+            first_at,
+        );
 
         loop {
             interval.tick().await; // Sleep until next interval

--- a/crates/core/src/heartbeat/runner.rs
+++ b/crates/core/src/heartbeat/runner.rs
@@ -112,41 +112,49 @@ impl HeartbeatRunner {
 
             // Run heartbeat with timing
             let start = Instant::now();
-            match self.run_once_internal().await {
+            info!(name: "Heartbeat", "tick starting at: {:?}", start);
+
+            let res = self.run_once_internal().await;
+            let elapsed = start.elapsed();
+            info!(name: "Heartbeat", "tick done elapsed: {:?}", elapsed);
+
+            let event = match res {
                 Ok((response, status)) => {
-                    let duration_ms = start.elapsed().as_millis() as u64;
                     let preview = if response.len() > 200 {
                         Some(format!("{}...", &response[..200]))
                     } else {
                         Some(response.clone())
                     };
 
-                    emit_heartbeat_event(HeartbeatEvent {
-                        ts: now_ms(),
-                        status,
-                        duration_ms,
-                        preview,
-                        reason: None,
-                    });
-
                     if is_heartbeat_ok(&response) {
                         debug!(name: "Heartbeat", "OK");
                     } else {
                         warn!(name: "Heartbeat", "response not OK: {}", response);
                     }
+
+                    HeartbeatEvent {
+                        ts: now_ms(),
+                        status: status.clone(),
+                        duration_ms: elapsed.as_millis() as u64,
+                        preview,
+                        reason: None,
+                    }
                 }
                 Err(e) => {
                     warn!(name: "Heartbeat", "error: {}", e);
-                    let duration_ms = start.elapsed().as_millis() as u64;
-                    emit_heartbeat_event(HeartbeatEvent {
+                    HeartbeatEvent {
                         ts: now_ms(),
                         status: HeartbeatStatus::Failed,
-                        duration_ms,
+                        duration_ms: elapsed.as_millis() as u64,
                         preview: None,
                         reason: Some(e.to_string()),
-                    });
+                    }
                 }
-            }
+            };
+
+            emit_heartbeat_event(event);
+
+            info!(name: "Heartbeat", "waiting for next tick");
         }
     }
 

--- a/crates/core/src/heartbeat/runner.rs
+++ b/crates/core/src/heartbeat/runner.rs
@@ -132,6 +132,11 @@ impl HeartbeatRunner {
             first_at,
         );
 
+        // Exponential backoff for SkippedMayTry retries
+        let mut skips_since_last = 0;
+        let skip_retry_base = Duration::from_millis(1000);
+        let skip_retry_max = self.interval / 2;
+
         loop {
             interval.tick().await; // Sleep until next interval
 
@@ -170,6 +175,16 @@ impl HeartbeatRunner {
                         warn!(name: "Heartbeat", "response not OK: {}", response);
                     }
 
+                    if status == HeartbeatStatus::SkippedMayTry {
+                        skips_since_last += 1;
+                        let retry_after =
+                            (skip_retry_base * 2_u32.pow(skips_since_last)).min(skip_retry_max);
+                        interval.reset_after(retry_after);
+                        info!(name: "Heartbeat", "transient skip, retry quickly after: {:?}", retry_after);
+                    } else {
+                        skips_since_last = 0;
+                    }
+
                     HeartbeatEvent {
                         ts: now_ms(),
                         status: status.clone(),
@@ -190,12 +205,14 @@ impl HeartbeatRunner {
                 }
             };
 
-            // Persist last heartbeat event to disk
-            if let Err(e) = serde_json::to_writer_pretty(
-                fs::File::create(self.config.paths.last_heartbeat())?,
-                &event,
-            ) {
-                warn!(name: "Heartbeat", "failed to write event: {}", e);
+            // Persist any non-transient heartbeat event to disk
+            if event.status != HeartbeatStatus::SkippedMayTry {
+                if let Err(e) = serde_json::to_writer_pretty(
+                    fs::File::create(self.config.paths.last_heartbeat())?,
+                    &event,
+                ) {
+                    warn!(name: "Heartbeat", "failed to write event: {}", e);
+                }
             }
 
             emit_heartbeat_event(event);
@@ -248,7 +265,10 @@ impl HeartbeatRunner {
             && gate.is_busy()
         {
             info!(name: "Heartbeat", "skipping: agent turn in flight (TurnGate busy)");
-            return Ok((HEARTBEAT_OK_TOKEN.to_string(), HeartbeatStatus::Skipped));
+            return Ok((
+                HEARTBEAT_OK_TOKEN.to_string(),
+                HeartbeatStatus::SkippedMayTry,
+            ));
         }
 
         // Try to acquire the cross-process workspace lock (non-blocking)
@@ -256,7 +276,10 @@ impl HeartbeatRunner {
             Some(guard) => guard,
             None => {
                 info!(name: "Heartbeat", "skipping: workspace locked by another process");
-                return Ok((HEARTBEAT_OK_TOKEN.to_string(), HeartbeatStatus::Skipped));
+                return Ok((
+                    HEARTBEAT_OK_TOKEN.to_string(),
+                    HeartbeatStatus::SkippedMayTry,
+                ));
             }
         };
 
@@ -267,7 +290,10 @@ impl HeartbeatRunner {
                 Some(permit) => Some(permit),
                 None => {
                     info!(name: "Heartbeat", "skipping: agent turn started between check and acquire");
-                    return Ok((HEARTBEAT_OK_TOKEN.to_string(), HeartbeatStatus::Skipped));
+                    return Ok((
+                        HEARTBEAT_OK_TOKEN.to_string(),
+                        HeartbeatStatus::SkippedMayTry,
+                    ));
                 }
             }
         } else {

--- a/crates/core/src/paths.rs
+++ b/crates/core/src/paths.rs
@@ -107,6 +107,10 @@ impl Paths {
         self.state_dir.join("localgpt.audit.jsonl")
     }
 
+    pub fn last_heartbeat(&self) -> PathBuf {
+        self.state_dir.join("last_heartbeat")
+    }
+
     /// Search index for a specific agent: cache_dir/memory/{agent_id}.sqlite
     pub fn search_index(&self, agent_id: &str) -> PathBuf {
         self.cache_dir

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -1064,6 +1064,7 @@ async fn heartbeat_status(State(state): State<Arc<AppState>>) -> Json<HeartbeatS
             HeartbeatStatus::Sent => "sent",
             HeartbeatStatus::Ok => "ok",
             HeartbeatStatus::Skipped => "skipped",
+            HeartbeatStatus::SkippedMayTry => "skipped",
             HeartbeatStatus::Failed => "failed",
         };
 


### PR DESCRIPTION
So my heartbeats stopped working somewhere between v0.1.3 and the currently unreleased v0.3.0 main.

I've been trying to diagnose and fix, mostly increasing the observability, consistency, and persistency of heartbeat interval timing.

Just finally got to a place where I can at least see the problem, so decided to share my WIP improvements for discussion.

What looks to be happening is some kind of hang (deadlock? livelock? unclear as yet...) with the TurnGate and the heartbeat runner; see below for logs.

The commits in this branch are reasonably clear, but to recap my changes:
- elevated all of the heartbeat runner logs from debug to info, since like "the ~~one~~ main job" of the server is to run the heartbeat reliably
- shifted to using a tokio interval rather than a raw sleep, this makes the timing period consistent and not perturbed by however long the heartbeat run itself takes
- persist the last heartbeat event into a json state file and...
- ...use that state to resume heartbeats **on time** after a restart, rather than waiting a full heartbeat interval for a first overdue tick
- differentiate transient skips ( ones that might readily go away on a retry ) and use that to quicken the heartbeat interval with backoff

Right so, now for the current diagnostics:
```
Feb 17 14:38:02 doral localgpt[524162]: 2026-02-17T19:38:02.222331Z  INFO localgpt_core::memory: Using OpenAI embedding provider: nomic-embed-text:v1.5
Feb 17 14:38:02 doral localgpt[524162]: 2026-02-17T19:38:02.222335Z  INFO localgpt_core::memory: Using OpenAI embedding provider: nomic-embed-text:v1.5
Feb 17 14:38:02 doral localgpt[524162]: 2026-02-17T19:38:02.222366Z  INFO localgpt_core::heartbeat::runner: starting runner with interval: 1800s
Feb 17 14:38:02 doral localgpt[524162]: 2026-02-17T19:38:02.222411Z  INFO localgpt_core::heartbeat::runner: first tick scheduled after: 60s at: Instant { tv_sec: 83333, tv_nsec: 349302103 }
Feb 17 14:38:02 doral localgpt[524162]: 2026-02-17T19:38:02.222550Z  INFO localgpt_server::http: Starting HTTP server on http://127.0.0.1:31327
Feb 17 14:38:02 doral localgpt[524162]: 2026-02-17T19:38:02.233782Z  INFO localgpt_core::memory: Using OpenAI embedding provider: nomic-embed-text:v1.5
Feb 17 14:38:02 doral localgpt[524162]: 2026-02-17T19:38:02.233830Z  INFO localgpt_server::telegram: Telegram bot: paired with user unknown (ID: 8410244203)
Feb 17 14:38:02 doral localgpt[524162]: 2026-02-17T19:38:02.702953Z  INFO localgpt_server::telegram: Starting Telegram bot...
Feb 17 14:38:03 doral localgpt[524162]: 2026-02-17T19:38:03.451915Z  INFO localgpt_core::agent: Created new session: a22f704e-1429-4310-95d1-0435e8fef3e2
Feb 17 14:38:19 doral localgpt[524162]: 2026-02-17T19:38:19.991746Z  INFO teloxide::update_listeners::polling: retrying getting updates in 1s
Feb 17 14:38:19 doral localgpt[524162]: 2026-02-17T19:38:19.991788Z ERROR teloxide::error_handlers: An error from the update listener: Network(reqwest::Error { kind: Request, url: "https://api.telegram.org/token:redacted/GetUpdates", source: TimedOut })
Feb 17 14:39:02 doral localgpt[524162]: 2026-02-17T19:39:02.223416Z  INFO localgpt_core::heartbeat::runner: tick starting at: Instant { tv_sec: 83333, tv_nsec: 350296439 }
Feb 17 14:39:02 doral localgpt[524162]: 2026-02-17T19:39:02.223450Z  INFO localgpt_core::heartbeat::runner: skipping: agent turn in flight (TurnGate busy)
Feb 17 14:39:02 doral localgpt[524162]: 2026-02-17T19:39:02.223456Z  INFO localgpt_core::heartbeat::runner: tick done elapsed: 49.984µs
Feb 17 14:39:02 doral localgpt[524162]: 2026-02-17T19:39:02.223467Z  INFO localgpt_core::heartbeat::runner: transient skip, retry quickly after: 2s
Feb 17 14:39:02 doral localgpt[524162]: 2026-02-17T19:39:02.223655Z  INFO localgpt_core::heartbeat::runner: waiting for next tick
Feb 17 14:39:04 doral localgpt[524162]: 2026-02-17T19:39:04.225230Z  INFO localgpt_core::heartbeat::runner: tick starting at: Instant { tv_sec: 83335, tv_nsec: 352116844 }
Feb 17 14:39:04 doral localgpt[524162]: 2026-02-17T19:39:04.225251Z  INFO localgpt_core::heartbeat::runner: skipping: agent turn in flight (TurnGate busy)
Feb 17 14:39:04 doral localgpt[524162]: 2026-02-17T19:39:04.225259Z  INFO localgpt_core::heartbeat::runner: tick done elapsed: 32.671µs
Feb 17 14:39:04 doral localgpt[524162]: 2026-02-17T19:39:04.225268Z  INFO localgpt_core::heartbeat::runner: transient skip, retry quickly after: 4s
Feb 17 14:39:04 doral localgpt[524162]: 2026-02-17T19:39:04.225400Z  INFO localgpt_core::heartbeat::runner: waiting for next tick
Feb 17 14:39:08 doral localgpt[524162]: 2026-02-17T19:39:08.226698Z  INFO localgpt_core::heartbeat::runner: tick starting at: Instant { tv_sec: 83339, tv_nsec: 353584154 }
Feb 17 14:39:08 doral localgpt[524162]: 2026-02-17T19:39:08.226724Z  INFO localgpt_core::heartbeat::runner: skipping: agent turn in flight (TurnGate busy)
Feb 17 14:39:08 doral localgpt[524162]: 2026-02-17T19:39:08.226729Z  INFO localgpt_core::heartbeat::runner: tick done elapsed: 36.248µs
Feb 17 14:39:08 doral localgpt[524162]: 2026-02-17T19:39:08.226736Z  INFO localgpt_core::heartbeat::runner: transient skip, retry quickly after: 8s
Feb 17 14:39:08 doral localgpt[524162]: 2026-02-17T19:39:08.226887Z  INFO localgpt_core::heartbeat::runner: waiting for next tick
```
and there the log stop, we do not in fact see another heartbeat runner wakeup after the promised 8s quickened interval.

Will update as I find more, but wanted to share earlier than "fully fixed it" :-)