### PR TITLE
Improve incremental session save reliability

### DIFF
--- a/crates/core/src/agent/mod.rs
+++ b/crates/core/src/agent/mod.rs
@@ -644,70 +644,60 @@ impl Agent {
     /// Used by the heartbeat runner so the session log is visible while the heartbeat is running.
     async fn handle_response_saving_session(
         &mut self,
-        response: LLMResponse,
+        mut response: LLMResponse,
         agent_id: &str,
     ) -> Result<String> {
-        // Track usage
-        self.add_usage(response.usage);
+        loop {
+            // Track usage
+            self.add_usage(response.usage);
 
-        match response.content {
-            LLMResponseContent::Text(text) => Ok(text),
-            LLMResponseContent::ToolCalls(calls) => {
-                // Execute tool calls
-                let mut results = Vec::new();
-
-                for call in &calls {
-                    debug!(
-                        "Executing tool: {} with args: {}",
-                        call.name, call.arguments
-                    );
-
-                    let result = self.execute_tool(call).await;
-                    let output = match result {
-                        Ok((content, _warnings)) => content,
-                        Err(e) => format!("Error: {}", e),
-                    };
-                    results.push(ToolResult {
-                        call_id: call.id.clone(),
-                        output,
-                    });
-                }
-
-                // Add tool call message
-                self.session.add_message(Message {
-                    role: Role::Assistant,
-                    content: String::new(),
-                    tool_calls: Some(calls),
-                    tool_call_id: None,
-                    images: Vec::new(),
-                });
-
-                // Add tool results
-                for result in &results {
+            match response.content {
+                LLMResponseContent::Text(text) => return Ok(text),
+                LLMResponseContent::ToolCalls(calls) => {
+                    // Add and save intent to call tools so it's visible during a long run
                     self.session.add_message(Message {
-                        role: Role::Tool,
-                        content: result.output.clone(),
-                        tool_calls: None,
-                        tool_call_id: Some(result.call_id.clone()),
+                        role: Role::Assistant,
+                        content: String::new(),
+                        tool_calls: Some(calls.clone()),
+                        tool_call_id: None,
                         images: Vec::new(),
                     });
+                    if let Err(e) = self.session.save_for_agent(agent_id) {
+                        debug!("Incremental session save failed: {}", e);
+                    }
+
+                    // Execute each tool call, saving session after each so that partial it's visible
+                    // during a long run, even partial progress if interrupted
+                    for call in &calls {
+                        debug!(
+                            "Executing tool: {} with args: {}",
+                            call.name, call.arguments
+                        );
+
+                        let result = self.execute_tool(call).await;
+                        self.session.add_message(Message {
+                            role: Role::Tool,
+                            content: match result {
+                                Ok((content, _warnings)) => content.clone(),
+                                Err(e) => format!("Error: {}", e),
+                            },
+                            tool_calls: None,
+                            tool_call_id: Some(call.id.clone()),
+                            images: Vec::new(),
+                        });
+                        if let Err(e) = self.session.save_for_agent(agent_id) {
+                            debug!("Incremental session save failed: {}", e);
+                        }
+                    }
+
+                    // Continue conversation with tool results (with per-turn security block)
+                    let messages = self.messages_for_api_call();
+                    let tool_schemas = self.tool_schemas_for_provider();
+                    response = self
+                        .provider
+                        .chat(&messages, Some(tool_schemas.as_slice()))
+                        .await?;
                 }
-
-                // Save session after each tool call round so it's visible during a long run
-                if let Err(e) = self.session.save_for_agent(agent_id) {
-                    debug!("Incremental session save failed: {}", e);
-                }
-
-                // Continue conversation with tool results (with per-turn security block)
-                let messages = self.messages_for_api_call();
-                let tool_schemas = self.tool_schemas_for_provider();
-                let next_response = self
-                    .provider
-                    .chat(&messages, Some(tool_schemas.as_slice()))
-                    .await?;
-
-                // Recursively handle (in case of more tool calls)
-                Box::pin(self.handle_response_saving_session(next_response, agent_id)).await
             }
         }
     }
@@ -715,7 +705,7 @@ impl Agent {
     /// Like `chat`, but saves the session log to `agent_id`'s sessions directory after each
     /// tool call round. Used by the heartbeat runner so in-progress sessions are visible.
     pub async fn chat_saving_session(&mut self, message: &str, agent_id: &str) -> Result<String> {
-        // Add user message
+        // Add user message and start out saved session file
         self.session.add_message(Message {
             role: Role::User,
             content: message.to_string(),
@@ -723,17 +713,28 @@ impl Agent {
             tool_call_id: None,
             images: Vec::new(),
         });
+        if let Err(e) = self.session.save_for_agent(agent_id) {
+            debug!("Incremental session save failed: {}", e);
+        }
 
         // Check if we should run pre-compaction memory flush (soft threshold)
         if self.should_memory_flush() {
             info!("Running pre-compaction memory flush (soft threshold)");
             self.memory_flush().await?;
+            if let Err(e) = self.session.save_for_agent(agent_id) {
+                debug!("Incremental session save failed: {}", e);
+            }
         }
 
         // Check if we need to compact (hard limit)
         if self.should_compact() {
             self.compact_session().await?;
+            if let Err(e) = self.session.save_for_agent(agent_id) {
+                debug!("Incremental session save failed: {}", e);
+            }
         }
+
+        // TODO y u no save
 
         // Build messages for LLM (with per-turn security block)
         let messages = self.messages_for_api_call();
@@ -760,6 +761,9 @@ impl Agent {
             tool_call_id: None,
             images: Vec::new(),
         });
+        if let Err(e) = self.session.save_for_agent(agent_id) {
+            debug!("Incremental session save failed: {}", e);
+        }
 
         Ok(final_response)
     }


### PR DESCRIPTION
- loop instead of recursion so that there are no incidental limits on tool call depth
- save session after *every* message append or compaction rewrite; between each tool call invocation itself, not just at the end of a batch of tool calls