### PR TITLE
fix(tui): collapse Right key match arm into a guard

### DIFF
--- a/crates/cli/src/cli/tui.rs
+++ b/crates/cli/src/cli/tui.rs
@@ -974,11 +974,11 @@ async fn run_app(
                                 app.cursor_position -= 1;
                             }
                         }
-                        KeyCode::Right => {
-                            if !app.is_generating && app.cursor_position < app.input.chars().count()
-                            {
-                                app.cursor_position += 1;
-                            }
+                        KeyCode::Right
+                            if !app.is_generating
+                                && app.cursor_position < app.input.chars().count() =>
+                        {
+                            app.cursor_position += 1;
                         }
                         _ => {}
                     }


### PR DESCRIPTION
Resolves clippy::collapsible_match by moving the !is_generating &&
cursor bounds check into the KeyCode::Right match guard.